### PR TITLE
Fix null message rendering

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -105,7 +105,7 @@ class Helpers {
 		} else if (answerFromCognigy && answerFromCognigy.data && answerFromCognigy.data._cognigy && answerFromCognigy.data._cognigy._facebook) {
 			var renderRichMessage = new RichMessages(answerFromCognigy.data._cognigy._facebook, chatContainer, readCognigyMessage, this.handleDisplayPostbackMessage, handleCognigyMessage, messageLogoUrl, this.displayCognigyMessage);
 			renderRichMessage.renderMessage();
-		} else if (typeof cognigyAnswer !== 'undefined') {
+		} else if (cognigyAnswer) {
 			var messageContainer = document.createElement("div");
 			var message = document.createElement("div");
 			var messageValue = document.createTextNode(cognigyAnswer);


### PR DESCRIPTION
**Bug**
Messages with an empty string ("") or of type **null** are rendered as an empty speech bubble.
![screenshot from 2018-08-14 11-25-06](https://user-images.githubusercontent.com/22472416/44083690-0070673e-9fb5-11e8-8cde-98443f09447b.png)
**Fix**
Edited check to skip rendering all messages where the message text is a falsey value.